### PR TITLE
Include new version of socket flags

### DIFF
--- a/internal/socktest/switch.go
+++ b/internal/socktest/switch.go
@@ -121,12 +121,13 @@ func (st stats) getLocked(c Cookie) *Stat {
 type FilterType int
 
 const (
-	FilterSocket        FilterType = iota // for Socket
-	FilterConnect                         // for Connect or ConnectEx
-	FilterListen                          // for Listen
-	FilterAccept                          // for Accept, Accept4 or AcceptEx
-	FilterGetsockoptInt                   // for GetsockoptInt
-	FilterClose                           // for Close or Closesocket
+	FilterSocket         FilterType = iota // for Socket
+	FilterConnect                          // for Connect or ConnectEx
+	FilterListen                           // for Listen
+	FilterAccept                           // for Accept, Accept4 or AcceptEx
+	FilterGetsockoptInt                    // for GetsockoptInt
+	FilterGetsockflagInt                   // for GetsockflagInt
+	FilterClose                            // for Close or Closesocket
 )
 
 // A Filter represents a socket system call filter.

--- a/srt/srt.go
+++ b/srt/srt.go
@@ -133,7 +133,7 @@ func (c *conn) SetWriteDeadline(t time.Time) error {
 
 // StreamID return stream ID
 func (c *conn) StreamID() (string, error) {
-	return srtapi.GetsockoptString(c.fd.pfd.Sysfd, 0, srtapi.OptionStreamid)
+	return srtapi.GetsockflagString(c.fd.pfd.Sysfd, srtapi.OptionStreamid)
 }
 
 func (c *conn) Stats() map[string]interface{} {

--- a/srtapi/srtapi_cgo.go
+++ b/srtapi/srtapi_cgo.go
@@ -164,6 +164,26 @@ func socket(domain int, typ int, proto int) (fd int, err error) {
 	return
 }
 
+func getsockflag(s int, name int, val unsafe.Pointer, vallen *_Socklen) (err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	stat := C.srt_getsockflag(C.SRTSOCKET(s), C.SRT_SOCKOPT(name), val, (*C.int)(vallen))
+	if stat == APIError {
+		err = getLastError()
+	}
+	return
+}
+
+func setsockflag(s int, name int, val unsafe.Pointer, vallen uintptr) (err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	stat := C.srt_setsockflag(C.SRTSOCKET(s), C.SRT_SOCKOPT(name), val, C.int(vallen))
+	if stat == APIError {
+		err = getLastError()
+	}
+	return
+}
+
 func getsockopt(s int, level int, name int, val unsafe.Pointer, vallen *_Socklen) (err error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()

--- a/srtapi/srtapi_posix.go
+++ b/srtapi/srtapi_posix.go
@@ -91,6 +91,26 @@ func GetsockoptString(fd, level, opt int) (string, error) {
 	return string(buf[:vallen]), nil
 }
 
+// GetsockflagInt call srt_getsockflag
+func GetsockflagInt(fd, opt int) (value int, err error) {
+	var n int32
+	vallen := _Socklen(4)
+	err = getsockflag(fd, opt, unsafe.Pointer(&n), &vallen)
+	return int(n), err
+}
+
+// GetsockflagString returns the string value of the socket flag for the
+// socket associated with a fd
+func GetsockflagString(fd, opt int) (string, error) {
+	buf := make([]byte, 256)
+	vallen := _Socklen(len(buf))
+	err := getsockflag(fd, opt, unsafe.Pointer(&buf[0]), &vallen)
+	if err != nil {
+		return "", err
+	}
+	return string(buf[:vallen]), nil
+}
+
 // SetsockoptByte call srt_setsockopt
 func SetsockoptByte(fd, level, opt int, value byte) (err error) {
 	return setsockopt(fd, level, opt, unsafe.Pointer(&value), 1)
@@ -120,6 +140,37 @@ func SetsockoptBool(fd, level, opt int, value bool) (err error) {
 		n = 1
 	}
 	return setsockopt(fd, level, opt, unsafe.Pointer(&n), 4)
+}
+
+// SetsockflagByte call srt_setsockopt
+func SetsockflagByte(fd, opt int, value byte) (err error) {
+	return setsockflag(fd, opt, unsafe.Pointer(&value), 1)
+}
+
+// SetsockflagInt call srt_setsockopt
+func SetsockflagInt(fd, opt int, value int) (err error) {
+	var n = int32(value)
+	return setsockflag(fd, opt, unsafe.Pointer(&n), 4)
+}
+
+// SetsockflagInt64 call srt_setsockopt
+func SetsockflagInt64(fd, opt int, value int64) (err error) {
+	var n = value
+	return setsockflag(fd, opt, unsafe.Pointer(&n), 8)
+}
+
+// SetsockflagString call srt_setsockopt
+func SetsockflagString(fd, opt int, s string) (err error) {
+	return setsockflag(fd, opt, unsafe.Pointer(&[]byte(s)[0]), uintptr(len(s)))
+}
+
+// SetsockflagBool call srt_setsockopt
+func SetsockflagBool(fd, opt int, value bool) (err error) {
+	var n = int32(0)
+	if value {
+		n = 1
+	}
+	return setsockflag(fd, opt, unsafe.Pointer(&n), 4)
 }
 
 // Socket call srt_socket


### PR DESCRIPTION
New functions do not receive the level parameter.

More info here: https://github.com/Haivision/srt/blob/master/docs/API.md#synopsis-4

Legacy version:

```c
int srt_getsockopt(SRTSOCKET socket, int level, SRT_SOCKOPT optName, void* optval, int& optlen);
int srt_setsockopt(SRTSOCKET socket, int level, SRT_SOCKOPT optName, const void* optval, int optlen);
```
New version:

```c
int srt_getsockflag(SRTSOCKET socket, SRT_SOCKOPT optName, void* optval, int& optlen);
int srt_setsockflag(SRTSOCKET socket, SRT_SOCKOPT optName, const void* optval, int optlen);
```